### PR TITLE
Fix welcome video not playing when using a gamepad controller.

### DIFF
--- a/src/assets/scripts/zoneItemMovement.js
+++ b/src/assets/scripts/zoneItemMovement.js
@@ -70,7 +70,7 @@
                 makeVisible(element);
             });
             webOverlayProperties.url = GIF_GAMEPAD_URL;
-            webGifOverlay = Overlays.addOverlay(WEB_OVERLAY_BASE_PROPERTIES);
+            webGifOverlay = Overlays.addOverlay('web3d', WEB_OVERLAY_BASE_PROPERTIES);
         } else {
             desktopEntities.forEach(function(element) {
                 if (wantDebug) {


### PR DESCRIPTION
This fixes this ticket https://highfidelity.manuscript.com/f/cases/14820/X-Box-controller-prevents-Welcome-video-at-Welcome-Station-to-play-in-tutorial